### PR TITLE
Added support for 'lines' diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ class MyComponent extends Component {
 
 You can also specify different values in `props.type`
 to compare in different ways. Valid values are `'chars'`,
-`'words'`, `'sentences'` and `'json'`:
+`'words'`, `'sentences'`, `'json'` and `'lines'`:
 
 
 ```javascript

--- a/dist/react-diff.js
+++ b/dist/react-diff.js
@@ -6,14 +6,15 @@ const fnMap = {
   'chars': jsdiff.diffChars,
   'words': jsdiff.diffWords,
   'sentences': jsdiff.diffSentences,
-  'json': jsdiff.diffJson
+  'json': jsdiff.diffJson,
+  'lines': (oldStr, newStr) => jsdiff.diffLines(oldStr, newStr, { newlineIsToken: true })
 };
 
 /**
  * Display diff in a stylable form.
  *
  * Default is character diff. Change with props.type. Valid values
- * are 'chars', 'words', 'sentences', 'json'.
+ * are 'chars', 'words', 'sentences', 'json', 'lines,.
  *
  *  - Wrapping div has class 'Difference', override with props.className
  *  - added parts are in <ins>

--- a/lib/react-diff.js
+++ b/lib/react-diff.js
@@ -6,14 +6,15 @@ const fnMap = {
   'chars': jsdiff.diffChars,
   'words': jsdiff.diffWords,
   'sentences': jsdiff.diffSentences,
-  'json': jsdiff.diffJson
+  'json': jsdiff.diffJson,
+  'lines': (oldStr, newStr) => jsdiff.diffLines(oldStr, newStr, {newlineIsToken: true})
 };
 
 /**
  * Display diff in a stylable form.
  *
  * Default is character diff. Change with props.type. Valid values
- * are 'chars', 'words', 'sentences', 'json'.
+ * are 'chars', 'words', 'sentences', 'json', 'lines,.
  *
  *  - Wrapping div has class 'Difference', override with props.className
  *  - added parts are in <ins>


### PR DESCRIPTION
I added support for a git style 'lines' diff . They don't render very nicely without pre-wrap, but since this library leaves styling to the end users I think that's fine. 
<img width="455" alt="screen shot 2018-05-09 at 10 56 33 am" src="https://user-images.githubusercontent.com/5900338/39822064-af3686e8-5377-11e8-858d-c72b059cb299.png">
